### PR TITLE
Update LaTeX error entry in the FAQ

### DIFF
--- a/doc/author-guide/faq.xml
+++ b/doc/author-guide/faq.xml
@@ -175,10 +175,32 @@
         </li>
 
         <li>
-            <title>My <latex /> output has errors.</title>
-            <p>Almost certainly your <pretext /> is not correct.  Or your <latex /> syntax within a math element (<tag>m</tag>, <tag>me</tag>, and friends) is not correct.  You have to be very deliberate to make legitimate <pretext /> that produces <latex /> that fails to compile.  The converse is that <latex /> compilation is a good check on the quality of your <pretext />, even if you do not care about print output for your project.</p>
+            <title>I have <latex /> errors</title>
+            <p>
+              If you have errors when you run <c>pdflatex</c> or <c>xelatex</c>,
+              that is more likely to be caused by a problem with your <latex /> installation
+              than with <pretext />.  It is difficult to make legitimate <pretext /> 
+              that fails to compile; an exception being math markup inside a math element
+              (<tag>m</tag>, <tag>me</tag>, and friends).
+            </p>
 
-            <p>If the <latex /> error does not help you locate the problem, a good first step in this case is to validate your <pretext /> source<mdash />see <xref ref="schema" />.</p>
+            <p>
+              To check your <latex /> installation, run <c>pdflatex -version</c>.  
+              If it reports something older than <q>TeX Live 2017</q>,
+              then updating may help.  If the trouble seems to be coming from a
+              particular package, then check which version of the package is being used.
+              For example, if the <q>tasks</q> package is causing a problem,
+              run <c>kpsewhich tasks.sty</c> in the directory where you are
+              compiling the <latex />.  If the package is in your personal
+              texmf tree, that may be the problem.
+            </p>
+
+            <p>
+              If the PDF is created without errors, but something looks wrong in the PDF,
+              then probably the <pretext /> source markup is wrong.  Validate your source
+              against the schema, and also carefully examine the HTML output.  
+              If that does not reveal the problem, seek expert help.
+            </p>
         </li>
 
         <li>


### PR DESCRIPTION
The LaTeX entry now emphasizes the likelihood that problems come from the installation.